### PR TITLE
fix(TEST-3): Adjusting initial version to 0.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conv-chang",
-  "version": "0.3.0",
+  "version": "0.0.0",
   "scripts": {
     "release": "standard-version"
   }


### PR DESCRIPTION
Initial value should probably be 0.0.0 because standard-version will probably increase the minor to 0.1.0 at the start.